### PR TITLE
Distinguish transient/confirmed failures + surface alert-suppression in UI

### DIFF
--- a/functions/src/bigquery.ts
+++ b/functions/src/bigquery.ts
@@ -93,6 +93,28 @@ export interface BigQueryCheckHistory {
   peer_status_code?: number;
   peer_checked_at?: number;      // unix-ms; converted to TIMESTAMP at insert
   peer_reachable?: boolean;
+  // Confirmation/alert audit (added so the UI can distinguish transient
+  // unconfirmed failures from confirmed transitions and show whether an
+  // alert actually fired).
+  //
+  // confirmed semantics:
+  //   - true  → status is the post-confirmation state (transition row, or
+  //             ongoing confirmed offline / online heartbeat)
+  //   - false → raw probe was offline but the confirmation streak hadn't
+  //             reached downConfirmationAttempts yet, so check.status was
+  //             held at "online" and no alert fired. The row is written
+  //             only because the peer was consulted; it's an audit trail.
+  //   - undefined on legacy rows pre-dating this column.
+  //
+  // alert_sent semantics:
+  //   - true   → triggerAlert was called for this transition AND delivered
+  //              at least one channel (email/SMS/webhook).
+  //   - false  → triggerAlert was called but suppressed (throttle, budget,
+  //              maintenance mode, settings).
+  //   - undefined → no alert attempt for this row (transient failure,
+  //                 heartbeat, peer-consulted non-transition).
+  confirmed?: boolean;
+  alert_sent?: boolean;
 }
 
 interface BigQueryInsertRow {
@@ -135,6 +157,13 @@ interface BigQueryInsertRow {
   peer_status_code?: number | null | undefined;
   peer_checked_at?: Date | null | undefined;
   peer_reachable?: boolean | null | undefined;
+  confirmed?: boolean | null | undefined;
+  alert_sent?: boolean | null | undefined;
+  // Marks rows recorded while the check was in maintenance mode. Incident
+  // calc filters these out so planned downtime doesn't inflate the user's
+  // outage minutes. (Previously declared on the source type but never
+  // persisted — fix #4.)
+  maintenance?: boolean | null | undefined;
 }
 
 interface BufferedBigQueryEntry {
@@ -341,6 +370,9 @@ const convertToRow = (data: BigQueryCheckHistory): BigQueryInsertRow => ({
   peer_status_code: data.peer_status_code ?? null,
   peer_checked_at: typeof data.peer_checked_at === 'number' ? new Date(data.peer_checked_at) : null,
   peer_reachable: typeof data.peer_reachable === 'boolean' ? data.peer_reachable : null,
+  confirmed: typeof data.confirmed === 'boolean' ? data.confirmed : null,
+  alert_sent: typeof data.alert_sent === 'boolean' ? data.alert_sent : null,
+  maintenance: typeof data.maintenance === 'boolean' ? data.maintenance : null,
 });
 
 type SchemaField = { name: string; type: string; mode?: "NULLABLE" | "REQUIRED" | "REPEATED" };
@@ -394,6 +426,15 @@ const DESIRED_SCHEMA: SchemaField[] = [
   { name: "peer_status_code", type: "INTEGER", mode: "NULLABLE" },
   { name: "peer_checked_at", type: "TIMESTAMP", mode: "NULLABLE" },
   { name: "peer_reachable", type: "BOOL", mode: "NULLABLE" },
+  // Confirmation/alert audit — populated by the runner; nullable for back-
+  // compat. Incident calc treats NULL as `true` (assume confirmed) so legacy
+  // rows aren't quietly dropped from past incident windows.
+  { name: "confirmed", type: "BOOL", mode: "NULLABLE" },
+  { name: "alert_sent", type: "BOOL", mode: "NULLABLE" },
+  // Set when the row was recorded inside a maintenance window. Incident
+  // calc filters these out so planned downtime never counts against the
+  // user's outage minutes.
+  { name: "maintenance", type: "BOOL", mode: "NULLABLE" },
 ];
 
 let schemaReadyPromise: Promise<void> | null = null;
@@ -819,6 +860,8 @@ export interface BigQueryCheckHistoryRow {
   peer_status_code?: number;
   peer_checked_at?: { value: string } | string | number;
   peer_reachable?: boolean;
+  confirmed?: boolean;
+  alert_sent?: boolean;
 }
 
 export interface BigQueryLatestStatusRow {
@@ -829,7 +872,15 @@ export interface BigQueryLatestStatusRow {
   status_code?: number;
 }
 
-// Minimal columns for list views (optimized for cost)
+// Minimal columns for list views (optimized for cost).
+// confirmed/alert_sent are tiny BOOLs that drive the table's Transient and
+// Bell badges; peer_checked_at is the canonical "peer was consulted"
+// predicate that drives the Peer badge's PRESENCE. Rich peer detail
+// (peer_status, peer_reachable, peer_response_time, peer_status_code,
+// peer_region) is deliberately kept OUT of MINIMAL — the tooltip in the
+// list view will surface "peer consulted" only; clicking through to the
+// detail sheet (which uses FULL_HISTORY_COLUMNS) renders the full peer
+// audit panel. This keeps paginated scan bytes close to pre-change levels.
 const MINIMAL_HISTORY_COLUMNS = `
   id,
   website_id,
@@ -838,7 +889,10 @@ const MINIMAL_HISTORY_COLUMNS = `
   status,
   response_time,
   status_code,
-  error
+  error,
+  confirmed,
+  alert_sent,
+  peer_checked_at
 `;
 
 // Full columns including all metadata (for detail views)
@@ -880,7 +934,9 @@ const FULL_HISTORY_COLUMNS = `
   peer_response_time,
   peer_status_code,
   peer_checked_at,
-  peer_reachable
+  peer_reachable,
+  confirmed,
+  alert_sent
 `;
 
 export const getCheckHistory = async (
@@ -1018,7 +1074,7 @@ export const getCheckHistoryDailySummary = async (
 ): Promise<DailySummary[]> => {
   try {
     // Aggregate by day: check if any entry had issues
-    // Issues = status IN ('offline', 'DOWN', 'REACHABLE_WITH_ERROR')
+    // Issues = (status IN ('offline', 'DOWN', 'REACHABLE_WITH_ERROR') AND COALESCE(confirmed, TRUE) = TRUE AND COALESCE(maintenance, FALSE) = FALSE)
     //   OR (error IS NOT NULL AND error != '') OR status_code >= 400 OR status_code < 0
     // Note: status_code < 0 catches timeouts and connection errors (e.g., -1)
     // Note: BigQuery stores timestamp as TIMESTAMP, so we use DATE() function
@@ -1049,7 +1105,7 @@ export const getCheckHistoryDailySummary = async (
         SELECT
           timestamp,
           CASE
-            WHEN UPPER(status) IN ('OFFLINE', 'DOWN', 'REACHABLE_WITH_ERROR') THEN 1
+            WHEN (UPPER(status) IN ('OFFLINE', 'DOWN', 'REACHABLE_WITH_ERROR') AND COALESCE(confirmed, TRUE) = TRUE AND COALESCE(maintenance, FALSE) = FALSE) THEN 1
             ELSE 0
           END AS is_offline,
           LEAD(timestamp) OVER (ORDER BY timestamp) AS next_timestamp
@@ -1285,7 +1341,7 @@ export const getCheckStats = async (
         SELECT
           timestamp,
           CASE
-            WHEN UPPER(status) IN ('OFFLINE', 'DOWN', 'REACHABLE_WITH_ERROR') THEN 1
+            WHEN (UPPER(status) IN ('OFFLINE', 'DOWN', 'REACHABLE_WITH_ERROR') AND COALESCE(confirmed, TRUE) = TRUE AND COALESCE(maintenance, FALSE) = FALSE) THEN 1
             ELSE 0
           END AS is_offline,
           LEAD(timestamp) OVER (ORDER BY timestamp) AS next_timestamp
@@ -1303,7 +1359,7 @@ export const getCheckStats = async (
         SELECT
           COUNT(*) AS totalChecks,
           COUNTIF(status IN ('online', 'UP', 'REDIRECT')) AS onlineChecks,
-          COUNTIF(status IN ('offline', 'DOWN', 'REACHABLE_WITH_ERROR')) AS offlineChecks,
+          COUNTIF((status IN ('offline', 'DOWN', 'REACHABLE_WITH_ERROR') AND COALESCE(confirmed, TRUE) = TRUE AND COALESCE(maintenance, FALSE) = FALSE)) AS offlineChecks,
           COUNTIF(response_time > 0) AS responseSampleCount,
           AVG(IF(response_time > 0, response_time, NULL)) AS avgResponseTime,
           MIN(IF(response_time > 0, response_time, NULL)) AS minResponseTime,
@@ -1491,7 +1547,7 @@ const _runMultiRangeRawScan = async (
     return [
       `COUNTIF(timestamp >= @start_${s}) AS totalChecks_${s}`,
       `COUNTIF(timestamp >= @start_${s} AND status IN ('online', 'UP', 'REDIRECT')) AS onlineChecks_${s}`,
-      `COUNTIF(timestamp >= @start_${s} AND status IN ('offline', 'DOWN', 'REACHABLE_WITH_ERROR')) AS offlineChecks_${s}`,
+      `COUNTIF(timestamp >= @start_${s} AND (status IN ('offline', 'DOWN', 'REACHABLE_WITH_ERROR') AND COALESCE(confirmed, TRUE) = TRUE AND COALESCE(maintenance, FALSE) = FALSE)) AS offlineChecks_${s}`,
       `COUNTIF(timestamp >= @start_${s} AND response_time > 0) AS responseSampleCount_${s}`,
       `AVG(IF(timestamp >= @start_${s} AND response_time > 0, response_time, NULL)) AS avgResponseTime_${s}`,
       `MIN(IF(timestamp >= @start_${s} AND response_time > 0, response_time, NULL)) AS minResponseTime_${s}`,
@@ -1538,7 +1594,7 @@ const _runMultiRangeRawScan = async (
       SELECT
         timestamp,
         CASE
-          WHEN UPPER(status) IN ('OFFLINE', 'DOWN', 'REACHABLE_WITH_ERROR') THEN 1
+          WHEN (UPPER(status) IN ('OFFLINE', 'DOWN', 'REACHABLE_WITH_ERROR') AND COALESCE(confirmed, TRUE) = TRUE AND COALESCE(maintenance, FALSE) = FALSE) THEN 1
           ELSE 0
         END AS is_offline,
         LEAD(timestamp) OVER (ORDER BY timestamp) AS next_timestamp
@@ -1839,7 +1895,7 @@ export const getCheckStatsBatch = async (
           website_id,
           timestamp,
           CASE
-            WHEN UPPER(status) IN ('OFFLINE', 'DOWN', 'REACHABLE_WITH_ERROR') THEN 1
+            WHEN (UPPER(status) IN ('OFFLINE', 'DOWN', 'REACHABLE_WITH_ERROR') AND COALESCE(confirmed, TRUE) = TRUE AND COALESCE(maintenance, FALSE) = FALSE) THEN 1
             ELSE 0
           END AS is_offline,
           LEAD(timestamp) OVER (PARTITION BY website_id ORDER BY timestamp) AS next_timestamp
@@ -1859,7 +1915,7 @@ export const getCheckStatsBatch = async (
           website_id,
           COUNT(*) AS totalChecks,
           COUNTIF(status IN ('online', 'UP', 'REDIRECT')) AS onlineChecks,
-          COUNTIF(status IN ('offline', 'DOWN', 'REACHABLE_WITH_ERROR')) AS offlineChecks,
+          COUNTIF((status IN ('offline', 'DOWN', 'REACHABLE_WITH_ERROR') AND COALESCE(confirmed, TRUE) = TRUE AND COALESCE(maintenance, FALSE) = FALSE)) AS offlineChecks,
           COUNTIF(response_time > 0) AS responseSampleCount,
           AVG(IF(response_time > 0, response_time, NULL)) AS avgResponseTime,
           MIN(IF(response_time > 0, response_time, NULL)) AS minResponseTime,
@@ -2062,12 +2118,12 @@ export const getIncidentIntervals = async (
         SELECT
           timestamp,
           CASE
-            WHEN UPPER(status) IN ('OFFLINE', 'DOWN', 'REACHABLE_WITH_ERROR') THEN 1
+            WHEN (UPPER(status) IN ('OFFLINE', 'DOWN', 'REACHABLE_WITH_ERROR') AND COALESCE(confirmed, TRUE) = TRUE AND COALESCE(maintenance, FALSE) = FALSE) THEN 1
             ELSE 0
           END AS is_offline,
           LAG(
             CASE
-              WHEN UPPER(status) IN ('OFFLINE', 'DOWN', 'REACHABLE_WITH_ERROR') THEN 1
+              WHEN (UPPER(status) IN ('OFFLINE', 'DOWN', 'REACHABLE_WITH_ERROR') AND COALESCE(confirmed, TRUE) = TRUE AND COALESCE(maintenance, FALSE) = FALSE) THEN 1
               ELSE 0
             END
           ) OVER (ORDER BY timestamp) AS prev_is_offline
@@ -2274,9 +2330,9 @@ export const getReportMetricsCombined = async (
           status,
           response_time,
           is_seed,
-          CASE WHEN UPPER(status) IN ('OFFLINE', 'DOWN', 'REACHABLE_WITH_ERROR') THEN 1 ELSE 0 END AS is_offline,
+          CASE WHEN (UPPER(status) IN ('OFFLINE', 'DOWN', 'REACHABLE_WITH_ERROR') AND COALESCE(confirmed, TRUE) = TRUE AND COALESCE(maintenance, FALSE) = FALSE) THEN 1 ELSE 0 END AS is_offline,
           LEAD(timestamp) OVER (ORDER BY timestamp) AS next_timestamp,
-          LAG(CASE WHEN UPPER(status) IN ('OFFLINE', 'DOWN', 'REACHABLE_WITH_ERROR') THEN 1 ELSE 0 END) OVER (ORDER BY timestamp) AS prev_is_offline
+          LAG(CASE WHEN (UPPER(status) IN ('OFFLINE', 'DOWN', 'REACHABLE_WITH_ERROR') AND COALESCE(confirmed, TRUE) = TRUE AND COALESCE(maintenance, FALSE) = FALSE) THEN 1 ELSE 0 END) OVER (ORDER BY timestamp) AS prev_is_offline
         FROM seeded
         WHERE timestamp <= @endDate
       ),
@@ -2293,7 +2349,7 @@ export const getReportMetricsCombined = async (
         SELECT
           COUNT(*) AS totalChecks,
           COUNTIF(status IN ('online', 'UP', 'REDIRECT')) AS onlineChecks,
-          COUNTIF(status IN ('offline', 'DOWN', 'REACHABLE_WITH_ERROR')) AS offlineChecks,
+          COUNTIF((status IN ('offline', 'DOWN', 'REACHABLE_WITH_ERROR') AND COALESCE(confirmed, TRUE) = TRUE AND COALESCE(maintenance, FALSE) = FALSE)) AS offlineChecks,
           COUNTIF(response_time > 0) AS responseSampleCount,
           AVG(IF(response_time > 0, response_time, NULL)) AS avgResponseTime,
           MIN(IF(response_time > 0, response_time, NULL)) AS minResponseTime,
@@ -2679,7 +2735,7 @@ export const getCheckHistoryDailySummaryBatch = async (
           website_id,
           timestamp,
           CASE
-            WHEN UPPER(status) IN ('OFFLINE', 'DOWN', 'REACHABLE_WITH_ERROR') THEN 1
+            WHEN (UPPER(status) IN ('OFFLINE', 'DOWN', 'REACHABLE_WITH_ERROR') AND COALESCE(confirmed, TRUE) = TRUE AND COALESCE(maintenance, FALSE) = FALSE) THEN 1
             ELSE 0
           END AS is_offline,
           LEAD(timestamp) OVER (PARTITION BY website_id ORDER BY timestamp) AS next_timestamp
@@ -2729,7 +2785,7 @@ export const getCheckHistoryDailySummaryBatch = async (
           DATE(timestamp) AS day,
           COUNT(*) AS total_checks,
           COUNTIF(status IN ('online', 'UP', 'REDIRECT')) AS online_checks,
-          COUNTIF(status IN ('offline', 'DOWN', 'REACHABLE_WITH_ERROR')) AS offline_checks
+          COUNTIF((status IN ('offline', 'DOWN', 'REACHABLE_WITH_ERROR') AND COALESCE(confirmed, TRUE) = TRUE AND COALESCE(maintenance, FALSE) = FALSE)) AS offline_checks
         FROM range_rows
         GROUP BY website_id, day
       )
@@ -2902,7 +2958,7 @@ export const aggregateDailySummaries = async (targetDate?: Date): Promise<number
             DATE(timestamp) AS day,
             COUNT(*) AS total_checks,
             COUNTIF(status IN ('online', 'UP', 'REDIRECT')) AS online_checks,
-            COUNTIF(status IN ('offline', 'DOWN', 'REACHABLE_WITH_ERROR')) AS offline_checks,
+            COUNTIF((status IN ('offline', 'DOWN', 'REACHABLE_WITH_ERROR') AND COALESCE(confirmed, TRUE) = TRUE AND COALESCE(maintenance, FALSE) = FALSE)) AS offline_checks,
             AVG(IF(response_time > 0, response_time, NULL)) AS avg_response_time,
             MIN(IF(response_time > 0, response_time, NULL)) AS min_response_time,
             MAX(IF(response_time > 0, response_time, NULL)) AS max_response_time
@@ -2935,7 +2991,7 @@ export const aggregateDailySummaries = async (targetDate?: Date): Promise<number
             website_id,
             user_id,
             timestamp,
-            CASE WHEN UPPER(status) IN ('OFFLINE', 'DOWN', 'REACHABLE_WITH_ERROR') THEN 1 ELSE 0 END AS is_offline,
+            CASE WHEN (UPPER(status) IN ('OFFLINE', 'DOWN', 'REACHABLE_WITH_ERROR') AND COALESCE(confirmed, TRUE) = TRUE AND COALESCE(maintenance, FALSE) = FALSE) THEN 1 ELSE 0 END AS is_offline,
             LEAD(timestamp) OVER (PARTITION BY website_id, user_id ORDER BY timestamp) AS next_timestamp
           FROM seeded
           WHERE timestamp <= @dayEnd

--- a/functions/src/check-utils.ts
+++ b/functions/src/check-utils.ts
@@ -485,7 +485,20 @@ export const createCheckHistoryRecord = (website: Website, checkResult: {
   edgeRayId?: string;
   edgeHeadersJson?: string;
   redirectLocation?: string;
-}, maintenance?: boolean, extras?: { region?: string; peer?: CheckHistoryPeerExtras }): BigQueryCheckHistory => {
+}, maintenance?: boolean, extras?: {
+  region?: string;
+  peer?: CheckHistoryPeerExtras;
+  // confirmed=false means the raw checkResult observed offline but the
+  // confirmation streak (downConfirmationAttempts) hadn't completed, so the
+  // check.status was held at the previous value and no alert fired. The row
+  // exists only as audit (peer was consulted). Treat undefined as confirmed
+  // (caller didn't think about it — applies to non-confirmation-gated paths
+  // like maintenance, post-deploy baseline, retry, error fallback).
+  confirmed?: boolean;
+  // alert_sent=true when triggerAlert delivered ≥1 channel for this row.
+  // Only meaningful on transition rows; undefined elsewhere.
+  alertSent?: boolean;
+}): BigQueryCheckHistory => {
   const now = Date.now();
   const peer = extras?.peer ?? null;
 
@@ -531,6 +544,8 @@ export const createCheckHistoryRecord = (website: Website, checkResult: {
     peer_status_code: peer?.statusCode ?? undefined,
     peer_checked_at: peer?.checkedAt ?? undefined,
     peer_reachable: peer ? peer.reachable : undefined,
+    confirmed: extras?.confirmed,
+    alert_sent: extras?.alertSent,
     ...(maintenance ? { maintenance: true } : {}),
   };
 };

--- a/functions/src/checks.ts
+++ b/functions/src/checks.ts
@@ -1436,7 +1436,28 @@ export async function processOneCheck(
       status = "online";
     }
 
-    const previousStatus = check.status ?? "unknown";
+    // previousStatus must reflect the same view of "what came before" that
+    // the alert path uses (`oldStatus` below). That path prefers the
+    // statusUpdateBuffer (more recent than Firestore) when present.
+    // Computing previousStatus from check.status alone caused alert_sent to
+    // miss real transitions whenever a buffered status update hadn't yet
+    // flushed — the alert fired but the history row was tagged as
+    // non-transition. Use one buffer-aware value for both decisions.
+    //
+    // Important: when both the buffer and the DB carry no useful status, we
+    // KEEP the value as "unknown" rather than collapsing it to the current
+    // probe's status. That preserves two invariants:
+    //   • the first-ever probe of a check always writes a history row
+    //     (because "unknown" !== status), and
+    //   • the alert gate's `oldStatus !== "unknown"` clause continues to
+    //     suppress a meaningless first-probe alert.
+    const previousStatusBufferedUpdate = statusUpdateBuffer.get(check.id);
+    const previousStatusFromBuffer =
+      previousStatusBufferedUpdate?.status && previousStatusBufferedUpdate.status.trim().length > 0
+        ? previousStatusBufferedUpdate.status
+        : null;
+    const previousStatusFromDb = check.status || "unknown";
+    const previousStatus = previousStatusFromBuffer ?? previousStatusFromDb;
     const historySampleIntervalMs = CONFIG.HISTORY_SAMPLE_INTERVAL_MS;
     const historyBucket =
       historySampleIntervalMs > 0 ? Math.floor(now / historySampleIntervalMs) : 0;
@@ -1456,12 +1477,48 @@ export async function processOneCheck(
     // BigQuery columns for peer fields land in Phase 2 Step 6 — until then
     // these rows just have NULL peer columns.
     const shouldRecordHistory = previousStatus !== status || shouldSampleHistory || peerResult !== null;
-    if (shouldRecordHistory) {
-      await enqueueHistoryRecord(createCheckHistoryRecord(check, checkResult, undefined, {
-        region: primaryRegion,
-        peer: peerResult,
-      }));
-    }
+    const isTransitionRow = previousStatus !== status;
+    // confirmed = the post-confirmation status agrees with the raw probe.
+    // - online probe → status stays online → confirmed=true
+    // - offline probe, threshold crossed → status flips offline → confirmed=true
+    // - offline probe held by confirmation gate or peer suppression → status
+    //   stays online while checkResult.status=offline → confirmed=false. The
+    //   row is audit-only; incident calc filters these out.
+    const rowConfirmed = status === checkResult.status;
+    // ── Deferred-enqueue contract ──
+    // We build the row now (so the data snapshot matches the current probe
+    // result) but DEFER the enqueue until finalizeHistoryRow() runs at the
+    // end of every return path. Two reasons:
+    //   (1) transition rows need alert_sent stamped from triggerAlert's
+    //       result, which doesn't exist yet at this point in the function;
+    //   (2) keeping the build site here means rowConfirmed is captured
+    //       BEFORE any later in-function mutation of `status` (e.g. the
+    //       DNS-drift override at ~line 1795 flips status to 'offline' for
+    //       drift-detection — the row continues to reflect the probe-time
+    //       confirmation state, not the post-drift override).
+    // Risk: if anything between here and the return throws unexpectedly,
+    // the row is silently lost. The body in between is mostly buffer
+    // writes (catch internally) + triggerAlert (catch internally), so the
+    // throw window is narrow. Worth revisiting if we see "missing audit
+    // row" reports for offline transitions.
+    const pendingHistoryRow = shouldRecordHistory
+      ? createCheckHistoryRecord(check, checkResult, undefined, {
+          region: primaryRegion,
+          peer: peerResult,
+          confirmed: rowConfirmed,
+        })
+      : null;
+    // Captures triggerAlert(...).delivered for the transition that THIS row
+    // represents; remains undefined for sample/peer-only audit rows so the
+    // UI can render "no alert attempt" distinct from "alert attempt failed".
+    let pendingAlertSent: boolean | undefined;
+    const finalizeHistoryRow = async () => {
+      if (!pendingHistoryRow) return;
+      if (pendingAlertSent !== undefined) {
+        pendingHistoryRow.alert_sent = pendingAlertSent;
+      }
+      await enqueueHistoryRecord(pendingHistoryRow);
+    };
     const historyRecordedAt = shouldRecordHistory ? now : undefined;
 
     // Peer status fields written on every probe — null when peer was not
@@ -1695,6 +1752,7 @@ export async function processOneCheck(
         }
       }
       await addStatusUpdate(check.id, noChangeUpdate);
+      await finalizeHistoryRow();
       return { id: check.id, status, responseTime, skipped: true, reason: "no-changes" };
     }
 
@@ -1877,20 +1935,11 @@ export async function processOneCheck(
       }
     }
 
-    // Alert logic — check buffer for authoritative previous status
-    const bufferedUpdate = statusUpdateBuffer.get(check.id);
-    const dbStatus = check.status || "unknown";
-    let oldStatus: string;
-    const bufferStatus = bufferedUpdate?.status && bufferedUpdate.status.trim().length > 0
-      ? bufferedUpdate.status
-      : null;
-    if (bufferStatus) {
-      oldStatus = bufferStatus;
-    } else if (dbStatus !== "unknown") {
-      oldStatus = dbStatus;
-    } else {
-      oldStatus = status;
-    }
+    // Alert logic — `previousStatus` (computed above with buffer awareness)
+    // is the same value the history-row decision uses, so the alert path
+    // and the audit-row path can't disagree about whether THIS probe is a
+    // transition.
+    const oldStatus = previousStatus;
 
     // Deploy-mode baseline: if this check hasn't run since deploy_mode was
     // last disabled, the current probe re-establishes the baseline silently.
@@ -1908,6 +1957,16 @@ export async function processOneCheck(
       updateData.pendingUpSince = null;
       if (oldStatus !== status) {
         logger.info(`Post-deploy baseline: ${oldStatus}→${status} for check ${check.id} (${check.name || check.url}) — alert suppressed`);
+        // Surface the suppression in the audit row so the UI's muted-bell
+        // tooltip can explain "no alert by design" instead of leaving the
+        // user staring at a transition row with no alert signal at all.
+        // Match the alert path's own gate (`oldStatus !== "unknown"`) — we
+        // only want to claim "suppressed" for transitions that would
+        // otherwise have alerted. First-probe transitions (unknown→X) are
+        // never alerted regardless of deploy mode, so don't mislabel them.
+        if (isTransitionRow && oldStatus !== "unknown") {
+          pendingAlertSent = false;
+        }
       }
     } else if (oldStatus !== status && oldStatus !== "unknown") {
       if (status === "offline") {
@@ -1933,6 +1992,12 @@ export async function processOneCheck(
         { consecutiveFailures: nextConsecutiveFailures, consecutiveSuccesses: nextConsecutiveSuccesses },
         { settings, throttleCache, budgetCache, emailMonthlyBudgetCache, smsThrottleCache, smsBudgetCache, smsMonthlyBudgetCache }
       );
+      // Stamp alert_sent onto the transition row that's about to be enqueued.
+      // Only transition rows carry meaningful alert_sent (heartbeats/peer-
+      // audit rows leave it null so the UI can tell them apart).
+      if (isTransitionRow) {
+        pendingAlertSent = result.delivered;
+      }
       applyPendingRetryFlags(updateData, result, status, now, check as Website & { pendingDownSince?: number; pendingUpSince?: number });
     } else {
       // Status didn't change — only retry previously failed alerts.
@@ -1974,6 +2039,7 @@ export async function processOneCheck(
       }
     }
     await addStatusUpdate(check.id, updateData);
+    await finalizeHistoryRow();
     return { id: check.id, status, responseTime };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : "Unknown error";
@@ -2006,16 +2072,33 @@ export async function processOneCheck(
       return { id: check.id, status: check.status || "online", error: errorMessage, skipped: true, reason: "confirming-down" };
     }
 
-    // Confirmed down
-    if ((check.status ?? "unknown") !== "offline") {
-      await enqueueHistoryRecord(
-        createCheckHistoryRecord(check, {
+    // Confirmed down — defer enqueue until after we know whether the alert
+    // attempt at the bottom of this branch was delivered, so the row can
+    // carry alert_sent. This is unconditionally a confirmed transition
+    // (we only get here after the shouldConfirmDown gate above returned).
+    // Use the same buffer-aware previous-status view that the alert path
+    // uses (`effectiveOldStatus` below), so "is this a transition row?"
+    // and "do we fire an alert?" can't disagree.
+    const errBufferedUpdate = statusUpdateBuffer.get(check.id);
+    const errPreviousStatus = errBufferedUpdate?.status && errBufferedUpdate.status.trim().length > 0
+      ? errBufferedUpdate.status
+      : (check.status || "unknown");
+    const isErrorTransitionRow = errPreviousStatus !== "offline";
+    const pendingErrorHistoryRow = isErrorTransitionRow
+      ? createCheckHistoryRecord(check, {
           status: "offline", responseTime: 0, statusCode: 0,
           error: errorMessage, timings: { totalMs: 0 },
-        }, undefined, { region: region as CheckRegion })
-      );
-    }
-    const historyRecordedAt = (check.status ?? "unknown") !== "offline" ? now : undefined;
+        }, undefined, { region: region as CheckRegion, confirmed: true })
+      : null;
+    let pendingErrorAlertSent: boolean | undefined;
+    const finalizeErrorHistoryRow = async () => {
+      if (!pendingErrorHistoryRow) return;
+      if (pendingErrorAlertSent !== undefined) {
+        pendingErrorHistoryRow.alert_sent = pendingErrorAlertSent;
+      }
+      await enqueueHistoryRecord(pendingErrorHistoryRow);
+    };
+    const historyRecordedAt = isErrorTransitionRow ? now : undefined;
 
     const hasChanges = check.status !== "offline" || check.lastError !== errorMessage;
 
@@ -2025,6 +2108,7 @@ export async function processOneCheck(
         updatedAt: now,
         nextCheckAt: CONFIG.getNextCheckAtMs(check.checkFrequency || CONFIG.CHECK_INTERVAL_MINUTES, now),
       });
+      await finalizeErrorHistoryRow();
       return { id: check.id, status: "offline", error: errorMessage, skipped: true, reason: "no-changes" };
     }
 
@@ -2045,11 +2129,9 @@ export async function processOneCheck(
       updateData.lastHistoryAt = historyRecordedAt;
     }
 
-    const bufferedUpdate = statusUpdateBuffer.get(check.id);
-    const effectiveOldStatus = bufferedUpdate?.status && bufferedUpdate.status.trim().length > 0
-      ? bufferedUpdate.status
-      : (check.status || "unknown");
-    const oldStatus = effectiveOldStatus;
+    // Reuse the same buffer-aware view computed above for the transition-row
+    // decision, so the alert path and the audit-row path stay aligned.
+    const oldStatus = errPreviousStatus;
 
     // Deploy-mode baseline: drop alerts entirely if this is the first run of
     // this check since deploy_mode lifted (see processOneCheck main path for
@@ -2065,6 +2147,13 @@ export async function processOneCheck(
       updateData.pendingUpSince = null;
       if (oldStatus !== "offline") {
         logger.info(`Post-deploy baseline (error path): ${oldStatus}→offline for check ${check.id} (${check.name || (check as Website).url}) — alert suppressed`);
+        // Mark the audit row so the UI can render "no alert by design".
+        // Match the alert path's own gate (`oldStatus !== "unknown"`) — a
+        // first-probe error wouldn't have alerted regardless of deploy
+        // mode, so we shouldn't claim it was "suppressed" by it.
+        if (isErrorTransitionRow && oldStatus !== "unknown") {
+          pendingErrorAlertSent = false;
+        }
       }
     } else if (oldStatus !== "offline" && oldStatus !== "unknown") {
       const settings = await getUserSettings(check.userId);
@@ -2078,6 +2167,7 @@ export async function processOneCheck(
         { consecutiveFailures: nextConsecutiveFailures },
         { settings, throttleCache, budgetCache, emailMonthlyBudgetCache, smsThrottleCache, smsBudgetCache, smsMonthlyBudgetCache }
       );
+      pendingErrorAlertSent = result.delivered;
       if (result.delivered) {
         updateData.pendingDownEmail = false;
         updateData.pendingDownSince = null;
@@ -2090,6 +2180,7 @@ export async function processOneCheck(
       }
     }
     await addStatusUpdate(check.id, updateData);
+    await finalizeErrorHistoryRow();
     return { id: check.id, status: "offline", error: errorMessage };
   }
 }

--- a/functions/src/history.ts
+++ b/functions/src/history.ts
@@ -337,6 +337,8 @@ export const getCheckHistoryBigQuery = onCall({
         peerStatusCode: entry.peer_status_code ?? undefined,
         peerCheckedAt: entry.peer_checked_at != null ? parseBigQueryTimestamp(entry.peer_checked_at, entry.id || 'unknown') : undefined,
         peerReachable: entry.peer_reachable ?? undefined,
+        confirmed: entry.confirmed ?? undefined,
+        alertSent: entry.alert_sent ?? undefined,
       };
     });
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -116,6 +116,9 @@ export interface CheckHistory {
   peerStatusCode?: number;
   peerCheckedAt?: number;
   peerReachable?: boolean;
+  // Confirmation/alert audit (see BigQueryCheckHistory in functions/src/bigquery.ts).
+  confirmed?: boolean;
+  alertSent?: boolean;
 }
 
 export interface LogNote {

--- a/src/components/logs/LogDetailsSheet.tsx
+++ b/src/components/logs/LogDetailsSheet.tsx
@@ -785,6 +785,48 @@ export const LogDetailsSheet: React.FC<LogDetailsSheetProps> = ({
                         </div>
                       )}
 
+                      {/* Alerting audit: explain WHY this row exists and what
+                          the alerting layer did with it. Shown whenever we have
+                          a confirmation or alert-delivery signal — typically
+                          on offline transitions and unconfirmed/peer-audit rows. */}
+                      {(typeof logEntry.confirmed === 'boolean' || typeof logEntry.alertSent === 'boolean') && (
+                        <div className="rounded-lg p-3 sm:p-4 bg-neutral-900/30 border border-neutral-800/50 space-y-3">
+                          <div className="flex flex-wrap items-center justify-between gap-2">
+                            <h3 className="text-sm font-medium text-foreground">Alerting</h3>
+                          </div>
+                          <div className="space-y-3">
+                            {typeof logEntry.confirmed === 'boolean' && (
+                              <div className="flex items-start justify-between gap-3">
+                                <span className="text-sm text-muted-foreground">Status confirmed</span>
+                                <span
+                                  className={`font-mono text-xs text-right ${
+                                    logEntry.confirmed ? 'text-green-300' : 'text-amber-300'
+                                  }`}
+                                >
+                                  {logEntry.confirmed
+                                    ? 'yes'
+                                    : 'no — single failure, held by down-confirmation threshold'}
+                                </span>
+                              </div>
+                            )}
+                            {typeof logEntry.alertSent === 'boolean' && (
+                              <div className="flex items-start justify-between gap-3">
+                                <span className="text-sm text-muted-foreground">Alert delivered</span>
+                                <span
+                                  className={`font-mono text-xs text-right ${
+                                    logEntry.alertSent ? 'text-green-300' : 'text-muted-foreground'
+                                  }`}
+                                >
+                                  {logEntry.alertSent
+                                    ? 'yes — at least one channel'
+                                    : 'no — suppressed (throttle, budget, maintenance mode, deploy mode, or alert settings)'}
+                                </span>
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                      )}
+
                       {/* Phase 2 multi-region: Region + peer-confirmation drilldown */}
                       {(logEntry.region || logEntry.peerCheckedAt != null) && (
                         <div className="rounded-lg p-3 sm:p-4 bg-neutral-900/30 border border-neutral-800/50 space-y-3">

--- a/src/pages/LogsBigQuery.tsx
+++ b/src/pages/LogsBigQuery.tsx
@@ -3,7 +3,7 @@ import { useAuth } from '@clerk/clerk-react';
 import { type DateRange } from "react-day-picker"
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
-import { List, FileText, FileSpreadsheet, Check, Info, X, Plus } from 'lucide-react';
+import { List, FileText, FileSpreadsheet, Check, Info, X, Plus, Bell, BellOff, Link2, Link2Off, AlertTriangle } from 'lucide-react';
 
 import { Button, FilterBar, StatusBadge, Badge, Pagination, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, GlowCard, ScrollArea, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, Alert, AlertDescription, Input, Label, Select, SelectContent, SelectItem, SelectTrigger, SelectValue, Textarea, Spinner, UpgradeBanner } from '../components/ui';
 import { PageHeader, PageContainer } from '../components/layout';
@@ -73,7 +73,10 @@ const getCacheTierDescription = (page: number): string => {
   return '1hour cache';
 };
 
-const getStatusBorderColor = (status: string) => {
+// Unconfirmed/transient offline rows get the warning border (yellow) so they
+// stand out from confirmed outages without being painted as alarming as red.
+// See LogEntry.confirmed in src/types/log-entry.ts for semantics.
+const getStatusBorderColor = (status: string, confirmed?: boolean) => {
   switch (status) {
     case 'online':
     case 'UP':
@@ -82,7 +85,7 @@ const getStatusBorderColor = (status: string) => {
     case 'offline':
     case 'DOWN':
     case 'REACHABLE_WITH_ERROR':
-      return 'border-l-red-500/50';
+      return confirmed === false ? 'border-l-amber-400/70' : 'border-l-red-500/50';
     case 'disabled':
       return 'border-l-amber-500/50';
     default:
@@ -133,6 +136,104 @@ const formatLocalDateTimeValue = (timestamp: number) => {
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
 };
 
+// Small inline chips next to the StatusBadge that explain WHY a row exists
+// and what the alerting layer did with it. Three independent signals:
+//   • Transient — offline probe held by the confirmation gate; check stayed
+//     "online" in our system so no alert fired (by design).
+//   • Peer — the EU↔US peer was consulted; tooltip surfaces what it saw.
+//   • Alert — bell when triggerAlert delivered ≥1 channel for this
+//     transition; muted bell when an attempt was suppressed/failed. Absent
+//     when no alert was attempted (heartbeat row, audit-only).
+const LogAuditChips: React.FC<{ item: LogEntry }> = ({ item }) => {
+  const isOffline = item.status === 'offline' || item.status === 'DOWN' || item.status === 'REACHABLE_WITH_ERROR';
+  const isTransient = isOffline && item.confirmed === false;
+  const peerWasConsulted = item.peerCheckedAt != null;
+  const hasAlertSignal = typeof item.alertSent === 'boolean';
+
+  if (!isTransient && !peerWasConsulted && !hasAlertSignal) return null;
+
+  return (
+    <TooltipProvider>
+      <div className="flex items-center gap-1">
+        {isTransient && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Badge variant="outline" className="text-[10px] font-mono leading-none border-amber-400/40 bg-amber-400/10 text-amber-400 px-1.5 py-0.5 flex items-center gap-1">
+                <AlertTriangle className="w-3 h-3" />
+                Transient
+              </Badge>
+            </TooltipTrigger>
+            <TooltipContent side="top" className="max-w-xs">
+              Single failed probe — held by your down-confirmation threshold.
+              The check stayed online; no alert was sent. This is by design,
+              to suppress one-off network blips.
+            </TooltipContent>
+          </Tooltip>
+        )}
+        {peerWasConsulted && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                className={`inline-flex items-center justify-center rounded border px-1 py-0.5 ${
+                  // peer_reachable / peer_status are not in MINIMAL_HISTORY_COLUMNS,
+                  // so on the list view they're typically undefined. Fall back
+                  // to a neutral "peer consulted" color and let the detail
+                  // sheet render the real peer outcome.
+                  item.peerStatus === 'online'
+                    ? 'border-primary/30 bg-primary/10 text-primary'
+                    : item.peerReachable === false
+                    ? 'border-muted/40 bg-muted/10 text-muted-foreground'
+                    : item.peerStatus === 'offline'
+                    ? 'border-destructive/30 bg-destructive/10 text-destructive'
+                    : 'border-primary/20 bg-primary/5 text-primary/80'
+                }`}
+                aria-label="Peer consulted"
+              >
+                {item.peerReachable === false ? (
+                  <Link2Off className="w-3 h-3" />
+                ) : (
+                  <Link2 className="w-3 h-3" />
+                )}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="top" className="max-w-xs">
+              <div className="space-y-1 text-xs">
+                <div className="font-semibold">Cross-region check</div>
+                <div>
+                  We consulted the peer region on this probe. Open the row
+                  for the peer's full reachability, status code and response
+                  time.
+                </div>
+              </div>
+            </TooltipContent>
+          </Tooltip>
+        )}
+        {hasAlertSignal && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                className={`inline-flex items-center justify-center rounded border px-1 py-0.5 ${
+                  item.alertSent
+                    ? 'border-primary/30 bg-primary/10 text-primary'
+                    : 'border-muted/40 bg-muted/10 text-muted-foreground'
+                }`}
+                aria-label={item.alertSent ? 'Alert sent' : 'Alert suppressed'}
+              >
+                {item.alertSent ? <Bell className="w-3 h-3" /> : <BellOff className="w-3 h-3" />}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="top" className="max-w-xs">
+              {item.alertSent
+                ? 'Alert delivered to at least one configured channel (email / SMS / webhook).'
+                : 'No alert delivered — suppressed by throttle, budget, maintenance mode, deploy mode, or alert settings. This is by design.'}
+            </TooltipContent>
+          </Tooltip>
+        )}
+      </div>
+    </TooltipProvider>
+  );
+};
+
 interface LogRowProps {
   item: LogEntry;
   index: number;
@@ -164,7 +265,7 @@ const LogRow = React.memo<LogRowProps>(({ item, index, animate, columnVisibility
       ? isMaintenance
         ? 'border-l-warning/60 bg-warning/5'
         : 'border-l-primary/60 bg-primary/5'
-      : getStatusBorderColor(item.status),
+      : getStatusBorderColor(item.status, item.confirmed),
     hasSlowStages ? 'bg-warning/5' : '',
     'border-l-4 transition-colors group cursor-pointer',
     animate ? 'animate-in fade-in slide-in-from-top-1 duration-500 ease-out' : ''
@@ -201,7 +302,14 @@ const LogRow = React.memo<LogRowProps>(({ item, index, animate, columnVisibility
       )}
       {columnVisibility.status && (
         <TableCell className="px-4 py-5">
-          <StatusBadge status={isMaintenance ? 'maintenance' : item.status} />
+          <div className="flex flex-col gap-1.5">
+            <div className="flex items-center gap-1.5">
+              <StatusBadge status={isMaintenance ? 'maintenance' : item.status} />
+              {/* Audit chips — only meaningful for auto-recorded probes,
+                  not manual/maintenance entries. */}
+              {!isManual && <LogAuditChips item={item} />}
+            </div>
+          </div>
         </TableCell>
       )}
       {columnVisibility.responseTime && (
@@ -727,6 +835,8 @@ const LogsBigQuery: React.FC = () => {
           peerStatusCode: entry.peerStatusCode,
           peerCheckedAt: entry.peerCheckedAt,
           peerReachable: entry.peerReachable,
+          confirmed: entry.confirmed,
+          alertSent: entry.alertSent,
         }));
         
         // Update pagination state - handle cost-optimized response (no total count)

--- a/src/types/log-entry.ts
+++ b/src/types/log-entry.ts
@@ -47,4 +47,14 @@ export interface LogEntry {
   peerStatusCode?: number;
   peerCheckedAt?: number;
   peerReachable?: boolean;
+  // confirmed=false marks an unconfirmed/transient probe failure that did
+  // NOT flip the check's status (held by the consecutive-failures gate or
+  // by peer suppression). UI renders these in yellow with an "unconfirmed"
+  // tooltip so the user understands no alert was sent by design.
+  confirmed?: boolean;
+  // alert_sent reflects whether triggerAlert delivered ≥1 channel for the
+  // status transition this row represents. Undefined on non-transition
+  // rows (heartbeats, peer-audit rows) so the UI can distinguish
+  // "alert attempted and failed" from "no alert attempt".
+  alertSent?: boolean;
 }


### PR DESCRIPTION
## Summary
- Adds `confirmed`, `alert_sent`, `maintenance` audit fields to BigQuery history rows and threads them end-to-end.
- Fixes the "single transient probe inflates incident chart by ~1 hour" issue: incident calc now filters out unconfirmed and maintenance rows, so planned downtime and one-off blips no longer count as outage minutes.
- Surfaces three new badges in the log UI (Transient / Peer / Bell) so the user can see at a glance why a row didn't trigger an alert.

## Origin
Customer (Qualisys) ran scheduled maintenance, saw an "Offline" row in our logs, and asked why no alert fired. Investigation showed it was a single 30-second timeout (held by their `downConfirmationAttempts: 4`), with all other probes successful — alerting worked correctly, but the log row labeled "Offline" gave them no way to tell that, and the daily chart computed the gap to the next sampled "Online" row (41 min later) as the "incident duration." Both surfaces needed fixing.

## What's in the rows now
- `confirmed` — post-confirmation status agrees with the raw probe. `false` on rows held by the confirmation gate or peer suppression.
- `alert_sent` — `triggerAlert` delivered ≥1 channel for this transition. Also set to `false` on intentional suppressions (deploy mode) so the UI can render "no alert by design."
- `maintenance` — was declared on the source type but never actually persisted; now plumbed all the way through.

## Incident-calc behavior
- All 17 offline-predicate query sites in `bigquery.ts` now read `AND COALESCE(confirmed, TRUE) = TRUE AND COALESCE(maintenance, FALSE) = FALSE`.
- Legacy rows have NULL for both and continue to count as confirmed/non-maintenance — no retroactive impact on historical dashboards.

## Probe-path correctness
- `previousStatus` is now buffer-aware in both main and error fallback paths, eliminating a race where a buffered status update made `triggerAlert` fire but the history row was tagged as a non-transition.
- Deferred-enqueue pattern keeps `alert_sent` accurate while preserving rowConfirmed against later in-function mutations (e.g. DNS-drift override).

## UI
- **Transient** chip (amber, AlertTriangle) when `confirmed === false` on an offline row.
- **Peer** chip (Link2 / Link2Off) when `peerCheckedAt` is set. Tooltip degrades cleanly to "open row for details" — rich peer detail is kept in FULL_HISTORY_COLUMNS only.
- **Bell / BellOff** chip driven by `alert_sent`; tooltip mentions throttle, budget, maintenance mode, deploy mode, settings.
- Row left-border switches from red to amber for unconfirmed offline rows.
- Detail sheet gains an "Alerting" panel.

## Schema migration
- Three new BOOL nullable columns auto-evolve via the existing `ensureCheckHistoryTableSchema` path on next scheduler run after deploy. No manual op required.

## Test plan
- [x] `npx tsc -b --noEmit` — clean
- [x] `cd functions && npm test` — 7/7 pass
- [x] ESLint on touched files — only pre-existing issues
- [ ] After deploy: query the new columns appear on fresh rows (`SELECT confirmed, alert_sent, maintenance FROM exit1-dev.checks.check_history_new ORDER BY timestamp DESC LIMIT 5`)
- [ ] Open the Logs page on a check with recent transient failures — verify amber "Transient" chip renders
- [ ] Open the Logs page on a check with a recent confirmed transition — verify "Bell" chip renders
- [ ] Open detail sheet — verify "Alerting" panel renders with confirmed / alert delivered rows

## Known gaps (deliberate, out of scope)
- DNS-drift transitions still don't get history rows (pre-existing).
- Old maintenance rows already in BigQuery have NULL `maintenance` and continue to count as offline in historical aggregates. Forward-looking fix only; happy to backfill in a separate PR if dashboards matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)